### PR TITLE
[PF-200] Add few basic validations for GCP resource Config

### DIFF
--- a/src/main/java/bio/terra/rbs/service/pool/AlwaysPassValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/AlwaysPassValidator.java
@@ -3,7 +3,7 @@ package bio.terra.rbs.service.pool;
 import bio.terra.rbs.generated.model.ResourceConfig;
 
 /** The default validator which does not no restrictions. */
-public class DefaultResourceConfigValidator implements ResourceConfigValidator {
+public class AlwaysPassValidator implements ResourceConfigValidator {
   @Override
   public void validate(ResourceConfig config) {
     // Always pass.

--- a/src/main/java/bio/terra/rbs/service/pool/AlwaysPassValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/AlwaysPassValidator.java
@@ -2,7 +2,7 @@ package bio.terra.rbs.service.pool;
 
 import bio.terra.rbs.generated.model.ResourceConfig;
 
-/** The default validator which does not no restrictions. */
+/** The validator which does not no restrictions. */
 public class AlwaysPassValidator implements ResourceConfigValidator {
   @Override
   public void validate(ResourceConfig config) {

--- a/src/main/java/bio/terra/rbs/service/pool/DefaultResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/DefaultResourceConfigValidator.java
@@ -1,0 +1,11 @@
+package bio.terra.rbs.service.pool;
+
+import bio.terra.rbs.generated.model.ResourceConfig;
+
+/** The default validator which does not require any restrictions on the config. */
+public class DefaultResourceConfigValidator implements ResourceConfigValidator {
+  @Override
+  public void validate(ResourceConfig config) {
+    // Always pass.
+  }
+}

--- a/src/main/java/bio/terra/rbs/service/pool/DefaultResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/DefaultResourceConfigValidator.java
@@ -2,7 +2,7 @@ package bio.terra.rbs.service.pool;
 
 import bio.terra.rbs.generated.model.ResourceConfig;
 
-/** The default validator which does not require any restrictions on the config. */
+/** The default validator which does not no restrictions. */
 public class DefaultResourceConfigValidator implements ResourceConfigValidator {
   @Override
   public void validate(ResourceConfig config) {

--- a/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
@@ -6,7 +6,13 @@ import bio.terra.rbs.generated.model.ResourceConfig;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
-/** Validates GCP resource configs */
+/**
+ * Validates GCP resource config. The current rules are:
+ * <ul>
+ *     <li> Billing account is required.
+ *     <li> compute.googleapis.com need to be enabled.
+ * </ul>
+ * */
 public class GcpResourceConfigValidator implements ResourceConfigValidator {
   /** List of services required to be enabled. */
   private static final List<String> REQUIRED_SERVICES = ImmutableList.of("compute.googleapis.com");

--- a/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /**
- * Validates GCP resource config. The current rules are:
+ * Validates GCP resource config. Because RBS creates customized network for all projects, this requires:
  * <ul>
  *     <li> Billing account is present.
  *     <li> compute.googleapis.com need to be enabled.

--- a/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Validates GCP resource config. The current rules are:
  * <ul>
- *     <li> Billing account is required.
+ *     <li> Billing account is present.
  *     <li> compute.googleapis.com need to be enabled.
  * </ul>
  * */

--- a/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
@@ -7,12 +7,14 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /**
- * Validates GCP resource config. Because RBS creates customized network for all projects, this requires:
+ * Validates GCP resource config. Because RBS creates customized network for all projects, this
+ * requires:
+ *
  * <ul>
- *     <li> Billing account is present.
- *     <li> compute.googleapis.com need to be enabled.
+ *   <li>Billing account is present.
+ *   <li>compute.googleapis.com need to be enabled.
  * </ul>
- * */
+ */
 public class GcpResourceConfigValidator implements ResourceConfigValidator {
   /** List of services required to be enabled. */
   private static final List<String> REQUIRED_SERVICES = ImmutableList.of("compute.googleapis.com");

--- a/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/GcpResourceConfigValidator.java
@@ -1,0 +1,29 @@
+package bio.terra.rbs.service.pool;
+
+import bio.terra.rbs.common.exception.InvalidPoolConfigException;
+import bio.terra.rbs.generated.model.GcpProjectConfig;
+import bio.terra.rbs.generated.model.ResourceConfig;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+/** Validates GCP resource configs */
+public class GcpResourceConfigValidator implements ResourceConfigValidator {
+  /** List of services required to be enabled. */
+  private static final List<String> REQUIRED_SERVICES = ImmutableList.of("compute.googleapis.com");
+
+  @Override
+  public void validate(ResourceConfig config) {
+    GcpProjectConfig gcpProjectConfig = config.getGcpProjectConfig();
+    if (gcpProjectConfig.getBillingAccount() == null
+        || gcpProjectConfig.getBillingAccount().isEmpty()) {
+      throw new InvalidPoolConfigException(
+          String.format("Missing billing account for config: %s", config.getConfigName()));
+    }
+
+    if (gcpProjectConfig.getEnabledApis() == null
+        || !gcpProjectConfig.getEnabledApis().containsAll(REQUIRED_SERVICES)) {
+      throw new InvalidPoolConfigException(
+          String.format("Missing required enabledApis for config: %s", config.getConfigName()));
+    }
+  }
+}

--- a/src/main/java/bio/terra/rbs/service/pool/PoolConfigLoader.java
+++ b/src/main/java/bio/terra/rbs/service/pool/PoolConfigLoader.java
@@ -36,6 +36,7 @@ public class PoolConfigLoader {
   public static List<PoolWithResourceConfig> loadPoolConfig(String folderName) {
     PoolConfigs poolConfigs = parsePools(folderName);
     Map<String, ResourceConfig> resourceConfigNameMap = parseResourceConfig(folderName);
+    validateResourceConfig(new ArrayList<>(resourceConfigNameMap.values()));
     return combineParsedConfig(poolConfigs, resourceConfigNameMap);
   }
 
@@ -106,5 +107,13 @@ public class PoolConfigLoader {
               poolConfig, resourceConfigNameMap.get(poolConfig.getResourceConfigName())));
     }
     return result;
+  }
+
+  /** Validates {@link ResourceConfig}. */
+  private static void validateResourceConfig(List<ResourceConfig> resourceConfigs) {
+    for (ResourceConfig config : resourceConfigs) {
+      ResourceConfigValidator validator = ResourceConfigValidatorFactory.getValidator(config);
+      validator.validate(config);
+    }
   }
 }

--- a/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidator.java
@@ -2,7 +2,11 @@ package bio.terra.rbs.service.pool;
 
 import bio.terra.rbs.generated.model.ResourceConfig;
 
-/** Validate {@link ResourceConfig} is valid. */
+/**
+ * Validate {@link ResourceConfig} is valid.
+ *
+ * <p>Throws a RuntimeException if validation does not succeed.
+ */
 public interface ResourceConfigValidator {
   void validate(ResourceConfig config);
 }

--- a/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidator.java
@@ -1,0 +1,8 @@
+package bio.terra.rbs.service.pool;
+
+import bio.terra.rbs.generated.model.ResourceConfig;
+
+/** Resource config validator to make sure config is valid. */
+public interface ResourceConfigValidator {
+  void validate(ResourceConfig config);
+}

--- a/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidator.java
+++ b/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidator.java
@@ -2,7 +2,7 @@ package bio.terra.rbs.service.pool;
 
 import bio.terra.rbs.generated.model.ResourceConfig;
 
-/** Resource config validator to make sure config is valid. */
+/** Validate {@link ResourceConfig} is valid. */
 public interface ResourceConfigValidator {
   void validate(ResourceConfig config);
 }

--- a/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidatorFactory.java
+++ b/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidatorFactory.java
@@ -1,0 +1,20 @@
+package bio.terra.rbs.service.pool;
+
+import bio.terra.rbs.common.ResourceConfigVisitor;
+import bio.terra.rbs.common.ResourceType;
+import bio.terra.rbs.generated.model.ResourceConfig;
+import org.springframework.stereotype.Component;
+
+/** Factory to return {ResourceConfigValidator} by {@link ResourceConfig}. */
+@Component
+public class ResourceConfigValidatorFactory {
+  public static ResourceConfigValidator getValidator(ResourceConfig resourceConfig) {
+    ResourceType type =
+        ResourceConfigVisitor.visit(resourceConfig, new ResourceConfigTypeVisitor()).get();
+    if (type.equals(ResourceType.GOOGLE_PROJECT)) {
+      return new GcpResourceConfigValidator();
+    } else {
+      return new DefaultResourceConfigValidator();
+    }
+  }
+}

--- a/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidatorFactory.java
+++ b/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidatorFactory.java
@@ -3,7 +3,6 @@ package bio.terra.rbs.service.pool;
 import bio.terra.rbs.common.ResourceConfigVisitor;
 import bio.terra.rbs.common.ResourceType;
 import bio.terra.rbs.generated.model.ResourceConfig;
-import org.springframework.stereotype.Component;
 
 /** Factory to return {ResourceConfigValidator} by {@link ResourceConfig}. */
 public class ResourceConfigValidatorFactory {

--- a/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidatorFactory.java
+++ b/src/main/java/bio/terra/rbs/service/pool/ResourceConfigValidatorFactory.java
@@ -6,7 +6,6 @@ import bio.terra.rbs.generated.model.ResourceConfig;
 import org.springframework.stereotype.Component;
 
 /** Factory to return {ResourceConfigValidator} by {@link ResourceConfig}. */
-@Component
 public class ResourceConfigValidatorFactory {
   public static ResourceConfigValidator getValidator(ResourceConfig resourceConfig) {
     ResourceType type =
@@ -14,7 +13,7 @@ public class ResourceConfigValidatorFactory {
     if (type.equals(ResourceType.GOOGLE_PROJECT)) {
       return new GcpResourceConfigValidator();
     } else {
-      return new DefaultResourceConfigValidator();
+      return new AlwaysPassValidator();
     }
   }
 }

--- a/src/main/resources/config/dev/resource-config/aou_ws_0_0_1.yml
+++ b/src/main/resources/config/dev/resource-config/aou_ws_0_0_1.yml
@@ -6,7 +6,7 @@ gcpProjectConfig:
   # TODO: Fill this
   parentFolderId: null
   # TODO: Fill this
-  billingAccount: null
+  billingAccount: "01A82E-CA8A14-367457"
   enabledApis:
     - "bigquery-json.googleapis.com"
     - "compute.googleapis.com"

--- a/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
@@ -58,57 +59,29 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testCreateGoogleProject_basicCreation() throws Exception {
+    // Basic GCP project with billing setup.
     FlightManager manager = new FlightManager(flightSubmissionFactoryImpl, stairwayComponent);
     Pool pool = preparePool(newBasicGcpConfig());
 
     String flightId = manager.submitCreationFlight(pool).get();
     blockUntilFlightComplete(flightId);
-    assertProjectExists(pool);
-  }
-
-  @Test
-  public void testCreateGoogleProject_withBillingAccount() throws Exception {
-    // Basic GCP project with billing setup.
-    FlightManager manager = new FlightManager(flightSubmissionFactoryImpl, stairwayComponent);
-    Pool pool = preparePool(newBasicGcpConfig().billingAccount(BILLING_ACCOUNT_NAME));
-
-    String flightId = manager.submitCreationFlight(pool).get();
-    blockUntilFlightComplete(flightId);
     Project project = assertProjectExists(pool);
     assertBillingIs(project, pool.resourceConfig().getGcpProjectConfig().getBillingAccount());
-  }
-
-  @Test
-  public void testCreateGoogleProject_withEnableService() throws Exception {
-    List<String> enabledServices =
-        Arrays.asList(
-            "bigquery.googleapis.com", "compute.googleapis.com", "cloudbilling.googleapis.com");
-
-    // Basic GCP project with billing setup and api enabled.
-    FlightManager manager = new FlightManager(flightSubmissionFactoryImpl, stairwayComponent);
-    Pool pool =
-        preparePool(
-            newBasicGcpConfig().billingAccount(BILLING_ACCOUNT_NAME).enabledApis(enabledServices));
-
-    String flightId = manager.submitCreationFlight(pool).get();
-    blockUntilFlightComplete(flightId);
-    Project project = assertProjectExists(pool);
     assertEnableApisContains(project, pool.resourceConfig().getGcpProjectConfig().getEnabledApis());
   }
 
   @Test
   public void testCreateGoogleProject_witIamBindings() throws Exception {
     // The groups used to test IAM policy sets up on a group. It doesn't matter what the users are
-    // for
-    // the purpose of this test. They just need to exist for Google. These groups were manually
-    // created for Broad
-    // development via the BITs service portal.
+    // for the purpose of this test. They just need to exist for Google.
+    // These groups were manually created for Broad development via the BITs service portal.
     String testGroupName = "terra-rbs-test@broadinstitute.org";
     String testGroupViewerName = "terra-rbs-viewer-test@broadinstitute.org";
+
     List<IamBinding> iamBindings =
         Arrays.asList(
-            new IamBinding().role("roles/editor").addMembersItem("group:" + testGroupName),
-            new IamBinding().role("roles/viewer").addMembersItem("group:" + testGroupViewerName));
+            new IamBinding().role("roles/owner").addMembersItem("group:" + testGroupName),
+            new IamBinding().role("roles/editor").addMembersItem("group:" + testGroupViewerName));
 
     // Basic GCP project with IAM Bindings
     FlightManager manager = new FlightManager(flightSubmissionFactoryImpl, stairwayComponent);
@@ -229,7 +202,11 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
 
   /** Create a Basic {@link ResourceConfig}. */
   private static GcpProjectConfig newBasicGcpConfig() {
-    return new GcpProjectConfig().projectIDPrefix("prefix").parentFolderId(FOLDER_ID);
+    return new GcpProjectConfig()
+        .projectIDPrefix("prefix")
+        .parentFolderId(FOLDER_ID)
+        .billingAccount(BILLING_ACCOUNT_NAME)
+        .addEnabledApisItem("compute.googleapis.com");
   }
 
   private Project assertProjectExists(Pool pool) throws Exception {
@@ -268,20 +245,21 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
 
   private void assertIamBindingsContains(Project project, List<IamBinding> iamBindings)
       throws Exception {
-    List<Binding> bindings =
-        iamBindings.stream()
-            .map(
-                iamBinding ->
-                    new Binding().setRole(iamBinding.getRole()).setMembers(iamBinding.getMembers()))
-            .collect(Collectors.toList());
-    assertThat(
-        new ArrayList<>(
-            rmCow
-                .projects()
-                .getIamPolicy(project.getProjectId(), new GetIamPolicyRequest())
-                .execute()
-                .getBindings()),
-        Matchers.hasItems(bindings.toArray()));
+    // By default we enable some services, and some GCP automatically creates SA accounts and grant
+    // permission
+    // e.g.,"serviceAccount:{projectId}-compute@developer.gserviceaccount.com" has editor role.
+    // So we need iterate all bindings and verify they contain the members & roles we expect.
+
+    Map<String, List<String>> allBindings =
+        rmCow.projects().getIamPolicy(project.getProjectId(), new GetIamPolicyRequest()).execute()
+            .getBindings().stream()
+            .collect(Collectors.toMap(Binding::getRole, Binding::getMembers));
+
+    for (IamBinding iamBinding : iamBindings) {
+      assertThat(
+          new ArrayList<>(allBindings.get(iamBinding.getRole())),
+          Matchers.hasItems(iamBinding.getMembers().toArray()));
+    }
   }
 
   /** A {@link FlightSubmissionFactory} used in test. */

--- a/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
@@ -80,8 +80,8 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
 
     List<IamBinding> iamBindings =
         Arrays.asList(
-            new IamBinding().role("roles/owner").addMembersItem("group:" + testGroupName),
-            new IamBinding().role("roles/editor").addMembersItem("group:" + testGroupViewerName));
+            new IamBinding().role("roles/editor").addMembersItem("group:" + testGroupName),
+            new IamBinding().role("roles/viewer").addMembersItem("group:" + testGroupViewerName));
 
     // Basic GCP project with IAM Bindings
     FlightManager manager = new FlightManager(flightSubmissionFactoryImpl, stairwayComponent);
@@ -246,7 +246,7 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
   private void assertIamBindingsContains(Project project, List<IamBinding> iamBindings)
       throws Exception {
     // By default we enable some services, and some GCP automatically creates SA accounts and grant
-    // permission
+    // permission.
     // e.g.,"serviceAccount:{projectId}-compute@developer.gserviceaccount.com" has editor role.
     // So we need iterate all bindings and verify they contain the members & roles we expect.
 

--- a/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
@@ -245,10 +245,12 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
 
   private void assertIamBindingsContains(Project project, List<IamBinding> iamBindings)
       throws Exception {
-    // By default we enable some services, and some GCP automatically creates SA accounts and grant
-    // permission.
+    // By default we enable some services, which causes GCP to automatically create Service Accounts
+    // and grant them
+    // permissions on the project.
     // e.g.,"serviceAccount:{projectId}-compute@developer.gserviceaccount.com" has editor role.
-    // So we need iterate all bindings and verify they contain the members & roles we expect.
+    // So we need to iterate through all bindings and verify they at least contain the members &
+    // roles we expect.
 
     Map<String, List<String>> allBindings =
         rmCow.projects().getIamPolicy(project.getProjectId(), new GetIamPolicyRequest()).execute()

--- a/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
@@ -246,8 +246,7 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
   private void assertIamBindingsContains(Project project, List<IamBinding> iamBindings)
       throws Exception {
     // By default we enable some services, which causes GCP to automatically create Service Accounts
-    // and grant them
-    // permissions on the project.
+    // and grant them permissions on the project.
     // e.g.,"serviceAccount:{projectId}-compute@developer.gserviceaccount.com" has editor role.
     // So we need to iterate through all bindings and verify they at least contain the members &
     // roles we expect.

--- a/src/test/java/bio/terra/rbs/service/pool/ResourceConfigValidatorTest.java
+++ b/src/test/java/bio/terra/rbs/service/pool/ResourceConfigValidatorTest.java
@@ -1,23 +1,25 @@
 package bio.terra.rbs.service.pool;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.rbs.common.BaseUnitTest;
 import bio.terra.rbs.common.exception.InvalidPoolConfigException;
 import bio.terra.rbs.generated.model.GcpProjectConfig;
 import bio.terra.rbs.generated.model.ResourceConfig;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 public class ResourceConfigValidatorTest extends BaseUnitTest {
+  private static GcpProjectConfig newValidGcpProjectConfig() {
+    return new GcpProjectConfig()
+        .billingAccount("123")
+        .addEnabledApisItem("compute.googleapis.com");
+  }
+
   @Test
   public void testValidateGcpConfig_success() {
     ResourceConfig resourceConfig =
-        new ResourceConfig()
-            .configName("testConfig")
-            .gcpProjectConfig(
-                new GcpProjectConfig()
-                    .billingAccount("123")
-                    .addEnabledApisItem("compute.googleapis.com"));
+        new ResourceConfig().configName("testConfig").gcpProjectConfig(newValidGcpProjectConfig());
     new GcpResourceConfigValidator().validate(resourceConfig);
   }
 
@@ -26,10 +28,12 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
     ResourceConfig resourceConfig =
         new ResourceConfig()
             .configName("testConfig")
-            .gcpProjectConfig(new GcpProjectConfig().addEnabledApisItem("compute.googleapis.com"));
-    assertThrows(
-        InvalidPoolConfigException.class,
-        () -> new GcpResourceConfigValidator().validate(resourceConfig));
+            .gcpProjectConfig(newValidGcpProjectConfig().billingAccount(""));
+    InvalidPoolConfigException exception =
+        assertThrows(
+            InvalidPoolConfigException.class,
+            () -> new GcpResourceConfigValidator().validate(resourceConfig));
+    assertTrue(exception.getMessage().contains("Missing billing account"));
   }
 
   @Test
@@ -37,9 +41,12 @@ public class ResourceConfigValidatorTest extends BaseUnitTest {
     ResourceConfig resourceConfig =
         new ResourceConfig()
             .configName("testConfig")
-            .gcpProjectConfig(new GcpProjectConfig().billingAccount("123"));
-    assertThrows(
-        InvalidPoolConfigException.class,
-        () -> new GcpResourceConfigValidator().validate(resourceConfig));
+            .gcpProjectConfig(
+                newValidGcpProjectConfig().enabledApis(ImmutableList.of("foo.googleapis.com")));
+    InvalidPoolConfigException exception =
+        assertThrows(
+            InvalidPoolConfigException.class,
+            () -> new GcpResourceConfigValidator().validate(resourceConfig));
+    assertTrue(exception.getMessage().contains("Missing required enabledApis"));
   }
 }

--- a/src/test/java/bio/terra/rbs/service/pool/ResourceConfigValidatorTest.java
+++ b/src/test/java/bio/terra/rbs/service/pool/ResourceConfigValidatorTest.java
@@ -1,0 +1,45 @@
+package bio.terra.rbs.service.pool;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.rbs.common.BaseUnitTest;
+import bio.terra.rbs.common.exception.InvalidPoolConfigException;
+import bio.terra.rbs.generated.model.GcpProjectConfig;
+import bio.terra.rbs.generated.model.ResourceConfig;
+import org.junit.jupiter.api.Test;
+
+public class ResourceConfigValidatorTest extends BaseUnitTest {
+  @Test
+  public void testValidateGcpConfig_success() {
+    ResourceConfig resourceConfig =
+        new ResourceConfig()
+            .configName("testConfig")
+            .gcpProjectConfig(
+                new GcpProjectConfig()
+                    .billingAccount("123")
+                    .addEnabledApisItem("compute.googleapis.com"));
+    new GcpResourceConfigValidator().validate(resourceConfig);
+  }
+
+  @Test
+  public void testValidateGcpConfig_missingBillingAccount() {
+    ResourceConfig resourceConfig =
+        new ResourceConfig()
+            .configName("testConfig")
+            .gcpProjectConfig(new GcpProjectConfig().addEnabledApisItem("compute.googleapis.com"));
+    assertThrows(
+        InvalidPoolConfigException.class,
+        () -> new GcpResourceConfigValidator().validate(resourceConfig));
+  }
+
+  @Test
+  public void testValidateGcpConfig_missingRequiredApis() {
+    ResourceConfig resourceConfig =
+        new ResourceConfig()
+            .configName("testConfig")
+            .gcpProjectConfig(new GcpProjectConfig().billingAccount("123"));
+    assertThrows(
+        InvalidPoolConfigException.class,
+        () -> new GcpResourceConfigValidator().validate(resourceConfig));
+  }
+}


### PR DESCRIPTION
Now we always create networks/subnets for a project. And it requires billing account and enabling compute api. 
So having a check here to catch error earlier.