### PR TITLE
[PF-217] Few improvements in test to reduce test time

### DIFF
--- a/src/test/java/bio/terra/rbs/db/RbsDaoTest.java
+++ b/src/test/java/bio/terra/rbs/db/RbsDaoTest.java
@@ -22,7 +22,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RbsDaoTest extends BaseUnitTest {
   @Autowired RbsJdbcConfiguration jdbcConfiguration;
   @Autowired RbsDao rbsDao;

--- a/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
@@ -102,11 +102,7 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     Pool pool = preparePool(rbsDao, newBasicGcpConfig().iamBindings(iamBindings));
 
     String flightId = manager.submitCreationFlight(pool).get();
-    System.out.println("~~~~~~start");
-    Stopwatch stopwatch = Stopwatch.createStarted();
     FlightMap resultMap = blockUntilFlightComplete(stairwayComponent, flightId).get();
-    System.out.println("~~~~~~stop");
-    System.out.println(stopwatch.stop().elapsed().toMinutes());
 
     Project project = assertProjectExists(ResourceId.retrieve(resultMap));
     assertIamBindingsContains(project, iamBindings);

--- a/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/CreateProjectFlightIntegrationTest.java
@@ -37,6 +37,7 @@ import com.google.api.services.compute.model.Subnetwork;
 import com.google.api.services.dns.model.ManagedZone;
 import com.google.api.services.dns.model.ResourceRecordSet;
 import com.google.api.services.serviceusage.v1.model.GoogleApiServiceusageV1Service;
+import com.google.common.base.Stopwatch;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,7 +51,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
   @Autowired RbsDao rbsDao;
   @Autowired StairwayComponent stairwayComponent;
@@ -101,7 +102,12 @@ public class CreateProjectFlightIntegrationTest extends BaseIntegrationTest {
     Pool pool = preparePool(rbsDao, newBasicGcpConfig().iamBindings(iamBindings));
 
     String flightId = manager.submitCreationFlight(pool).get();
+    System.out.println("~~~~~~start");
+    Stopwatch stopwatch = Stopwatch.createStarted();
     FlightMap resultMap = blockUntilFlightComplete(stairwayComponent, flightId).get();
+    System.out.println("~~~~~~stop");
+    System.out.println(stopwatch.stop().elapsed().toMinutes());
+
     Project project = assertProjectExists(ResourceId.retrieve(resultMap));
     assertIamBindingsContains(project, iamBindings);
   }

--- a/src/test/java/bio/terra/rbs/integration/DeleteProjectFlightIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/DeleteProjectFlightIntegrationTest.java
@@ -21,7 +21,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.test.annotation.DirtiesContext;
 
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DeleteProjectFlightIntegrationTest extends BaseIntegrationTest {
   @Autowired RbsDao rbsDao;
   @Autowired StairwayComponent stairwayComponent;

--- a/src/test/java/bio/terra/rbs/integration/IntegrationUtils.java
+++ b/src/test/java/bio/terra/rbs/integration/IntegrationUtils.java
@@ -12,6 +12,7 @@ import bio.terra.rbs.service.stairway.StairwayComponent;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.exception.DatabaseOperationException;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import java.time.Instant;
@@ -27,8 +28,8 @@ public class IntegrationUtils {
   /** The billing account to use in test. */
   public static final String BILLING_ACCOUNT_NAME = "01A82E-CA8A14-367457";
 
-  private static final Duration PERIOD = Duration.ofSeconds(10);
-  private static final int MAX_POLL_NUM = 40;
+  private static final Duration PERIOD = Duration.ofSeconds(4);
+  private static final int MAX_POLL_NUM = 100;
 
   public static List<Resource> pollUntilResourcesMatch(
       RbsDao rbsDao, PoolId poolId, ResourceState state, int expectedResourceNum) throws Exception {
@@ -50,14 +51,14 @@ public class IntegrationUtils {
   public static Optional<FlightMap> blockUntilFlightComplete(
       StairwayComponent stairwayComponent, String flightId)
       throws InterruptedException, DatabaseOperationException {
-    Duration maxWait = Duration.ofSeconds(10);
+    Duration maxWait = Duration.ofSeconds(500);
     Duration waited = Duration.ZERO;
     while (waited.compareTo(maxWait) < 0) {
       if (!stairwayComponent.get().getFlightState(flightId).isActive()) {
         return stairwayComponent.get().getFlightState(flightId).getResultMap();
       }
-      Duration poll = Duration.ofMillis(100);
-      waited.plus(Duration.ofMillis(poll.toMillis()));
+      Duration poll = Duration.ofMillis(4000);
+      waited = waited.plus(Duration.ofMillis(poll.toMillis()));
       TimeUnit.MILLISECONDS.sleep(poll.toMillis());
     }
     throw new InterruptedException("Flight did not complete in time.");

--- a/src/test/java/bio/terra/rbs/integration/RbsIntegrationTest.java
+++ b/src/test/java/bio/terra/rbs/integration/RbsIntegrationTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"test", "integration", "integration-enable-scheduler"})
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RbsIntegrationTest extends BaseIntegrationTest {
   @Autowired CloudResourceManagerCow rmCow;
 

--- a/src/test/java/bio/terra/rbs/service/pool/PoolServiceTest.java
+++ b/src/test/java/bio/terra/rbs/service/pool/PoolServiceTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.transaction.TransactionStatus;
 
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class PoolServiceTest extends BaseUnitTest {
   @Autowired PoolService poolService;
   @Autowired RbsDao rbsDao;

--- a/src/test/java/bio/terra/rbs/service/resource/flight/LatchStepTest.java
+++ b/src/test/java/bio/terra/rbs/service/resource/flight/LatchStepTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.annotation.DirtiesContext;
  * https://github.com/DataBiosphere/terra-resource-janitor/blob/master/src/test/java/bio/terra/janitor/service/cleanup/flight/LatchStepTest.java
  */
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class LatchStepTest extends BaseUnitTest {
   @Autowired StairwayComponent stairwayComponent;
 

--- a/src/test/resources/application-integration-enable-scheduler.yml
+++ b/src/test/resources/application-integration-enable-scheduler.yml
@@ -2,3 +2,4 @@ rbs:
   primary:
     # Enable scheduler service which will submit flight by scanning db.
     scheduler-enabled: true
+    flight-submission-period: 5s


### PR DESCRIPTION
1. BEFORE_EACH_TEST_METHOD should be AFTER, as we want to mark the ApplicationContext dirty after test.
2. Reduce polling period and increase polling number
3. `Duration.plus` returns a copy of the duraion, so we need to use the new copy: 
`waited = waited.plus(Duration.ofMillis(poll.toMillis())); `
4. Reduce flight-submission-period in test