### PR TITLE
[PF-196] Add cleanup_record table to track the resources published to Janitor

### DIFF
--- a/src/main/java/bio/terra/rbs/db/RbsDao.java
+++ b/src/main/java/bio/terra/rbs/db/RbsDao.java
@@ -295,6 +295,46 @@ public class RbsDao {
     return jdbcTemplate.update(sql, params) == 1;
   }
 
+  /** Inserts a record into cleanup_record table. */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void insertCleanupRecord(ResourceId resourceId) {
+    String sql = "INSERT INTO cleanup_record (resource_id) values (:resource_id)";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("resource_id", resourceId.id());
+
+    jdbcTemplate.update(sql, params);
+  }
+
+  /**
+   * Retrieves resources that need to cleanup by Janitor. Those resources should be:
+   *
+   * <ul>
+   *   <li>State is HANDED_OUT in resource table
+   *   <li>Handed out before given {@code handedOutBefore}
+   *   <li>Not already in cleanup_record table
+   * </ul>
+   */
+  @Transactional(propagation = Propagation.SUPPORTS)
+  public List<Resource> retrieveResourceToCleanup(Instant handedOutBefore, int limit) {
+    String sql =
+        "select r.id, r.cloud_resource_uid, r.pool_id, r.state, r.request_handout_id, "
+            + "r.creation, r.deletion, r.handout_time "
+            + "FROM resource r "
+            + "LEFT JOIN cleanup_record c ON r.id = c.resource_id "
+            + "WHERE r.state = :state "
+            + "AND handout_time <= :handout_before "
+            + "AND c.resource_id IS NULL "
+            + "LIMIT :limit";
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("state", ResourceState.HANDED_OUT.toString())
+            .addValue("handout_before", handedOutBefore.atOffset(ZoneOffset.UTC))
+            .addValue("limit", limit);
+
+    return jdbcTemplate.query(sql, params, RESOURCE_ROW_MAPPER);
+  }
+
   private static final RowMapper<Pool> POOL_ROW_MAPPER =
       (rs, rowNum) ->
           Pool.builder()

--- a/src/main/resources/db/changesets/20200925_initial_schema.yaml
+++ b/src/main/resources/db/changesets/20200925_initial_schema.yaml
@@ -107,6 +107,7 @@ databaseChangeLog:
                   nullable: true
                   unique: false
       - createTable:
+          # This will be only used in testing environment to track resources that are published to Janitor after handed out.
           tableName: cleanup_record
           columns:
             - column:

--- a/src/main/resources/db/changesets/20200925_initial_schema.yaml
+++ b/src/main/resources/db/changesets/20200925_initial_schema.yaml
@@ -117,5 +117,5 @@ databaseChangeLog:
                   primaryKey: true
                   references: resource(id)
                   foreignKeyName: fk_resource_id
-                  unique: false
+                  unique: true
                   nullable: false

--- a/src/main/resources/db/changesets/20200925_initial_schema.yaml
+++ b/src/main/resources/db/changesets/20200925_initial_schema.yaml
@@ -106,3 +106,15 @@ databaseChangeLog:
                 constraints:
                   nullable: true
                   unique: false
+      - createTable:
+          tableName: cleanup_record
+          columns:
+            - column:
+                name: resource_id
+                type: uuid
+                constraints:
+                  primaryKey: true
+                  references: resource(id)
+                  foreignKeyName: fk_resource_id
+                  unique: false
+                  nullable: false

--- a/src/test/java/bio/terra/rbs/db/RbsDaoTest.java
+++ b/src/test/java/bio/terra/rbs/db/RbsDaoTest.java
@@ -225,4 +225,28 @@ public class RbsDaoTest extends BaseUnitTest {
     assertEquals(now, resource.deletion());
     assertEquals(ResourceState.DELETED, resource.state());
   }
+
+  @Test
+  public void insertAndRetrieveCleanupRecord() {
+    // Prepare 2 HANDED_OUT and 1 READY resources.
+    Pool pool = newPool(PoolId.create("poolId"));
+    Resource handedOutR1 = newResource(pool.id(), ResourceState.READY);
+    Resource handedOutR2 = newResource(pool.id(), ResourceState.READY);
+    Resource readyR1 = newResource(pool.id(), ResourceState.READY);
+    rbsDao.createPools(ImmutableList.of(pool));
+    rbsDao.createResource(handedOutR1);
+    rbsDao.createResource(handedOutR2);
+    rbsDao.createResource(readyR1);
+    rbsDao.updateResourceAsHandedOut(handedOutR1.id(), RequestHandoutId.create("1111"));
+    rbsDao.updateResourceAsHandedOut(handedOutR2.id(), RequestHandoutId.create("2222"));
+
+    // handedOutR1 is already in cleanup_record table, expect only handedOutR2 is returned.
+    rbsDao.insertCleanupRecord(handedOutR1.id());
+    assertThat(
+        rbsDao.retrieveResourceToCleanup(Instant.now(), 1),
+        Matchers.contains(rbsDao.retrieveResource(handedOutR2.id()).get()));
+
+    // No resource will be returned if handout_time is after handedOutBefore time.
+    assertTrue(rbsDao.retrieveResourceToCleanup(Instant.now().minusSeconds(60), 1).isEmpty());
+  }
 }

--- a/src/test/java/bio/terra/rbs/db/RbsDaoTest.java
+++ b/src/test/java/bio/terra/rbs/db/RbsDaoTest.java
@@ -243,10 +243,7 @@ public class RbsDaoTest extends BaseUnitTest {
     // handedOutR1 is already in cleanup_record table, expect only handedOutR2 is returned.
     rbsDao.insertCleanupRecord(handedOutR1.id());
     assertThat(
-        rbsDao.retrieveResourceToCleanup(Instant.now(), 1),
+        rbsDao.retrieveResourceToCleanup(1),
         Matchers.contains(rbsDao.retrieveResource(handedOutR2.id()).get()));
-
-    // No resource will be returned if handout_time is after handedOutBefore time.
-    assertTrue(rbsDao.retrieveResourceToCleanup(Instant.now().minusSeconds(60), 1).isEmpty());
   }
 }


### PR DESCRIPTION
In my next PR, there will be a scheduler:
```
List<Resource> resources = rbsDao.retrieveResourceToCleanup();
for(Resource resource : resources) {
   publish(resource);
   insertCleanupRecord(resource.id());
}
```